### PR TITLE
BUILD-889: Use go-toolset 1.21 by Digest

### DIFF
--- a/.docker/controller/Dockerfile
+++ b/.docker/controller/Dockerfile
@@ -1,5 +1,5 @@
 # --- start build stage #1
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:5c948cdfd0132e982426bc9d3a81eeae66871080ef274abdde1a4a8303509188 AS builder
 
 COPY . .
 
@@ -8,7 +8,7 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -o /tmp/openshift-builds-controller ./cmd/shipwright-build-controller
 
 # --- start build stage #2
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
 
 # add labels
 LABEL \

--- a/.docker/git-cloner/Dockerfile
+++ b/.docker/git-cloner/Dockerfile
@@ -1,5 +1,5 @@
 # --- start build stage #1
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:5c948cdfd0132e982426bc9d3a81eeae66871080ef274abdde1a4a8303509188 AS builder
 
 COPY . .
 
@@ -8,7 +8,7 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -o /tmp/openshift-builds-git-cloner ./cmd/git
 
 # --- start build stage #2
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
 
 LABEL \
     com.redhat.component="openshift-builds-git-cloner" \

--- a/.docker/image-bundler/Dockerfile
+++ b/.docker/image-bundler/Dockerfile
@@ -1,5 +1,5 @@
 # --- start build stage #1
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:5c948cdfd0132e982426bc9d3a81eeae66871080ef274abdde1a4a8303509188 AS builder
 
 COPY . .
 
@@ -8,7 +8,7 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -o /tmp/openshift-builds-image-bundler ./cmd/bundle
 
 # --- start build stage #2
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
 
 LABEL \
     com.redhat.component="openshift-builds-image-bundler" \

--- a/.docker/image-processing/Dockerfile
+++ b/.docker/image-processing/Dockerfile
@@ -1,5 +1,5 @@
 # --- start build stage #1
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:5c948cdfd0132e982426bc9d3a81eeae66871080ef274abdde1a4a8303509188 AS builder
 
 COPY . .
 
@@ -8,7 +8,7 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -o /tmp/openshift-builds-image-processing ./cmd/image-processing
 
 # --- start build stage #2
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
 
 LABEL \
     com.redhat.component="openshift-builds-image-processing" \

--- a/.docker/waiter/Dockerfile
+++ b/.docker/waiter/Dockerfile
@@ -1,5 +1,5 @@
 # --- start build stage #1
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:5c948cdfd0132e982426bc9d3a81eeae66871080ef274abdde1a4a8303509188 AS builder
 
 COPY . .
 
@@ -8,7 +8,7 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -o /tmp/openshift-builds-waiter ./cmd/waiter
 
 # --- start build stage #2
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
 
 LABEL \
     com.redhat.component="openshift-builds-waiter" \

--- a/.docker/webhook/Dockerfile
+++ b/.docker/webhook/Dockerfile
@@ -1,5 +1,5 @@
 # --- start build stage #1
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:5c948cdfd0132e982426bc9d3a81eeae66871080ef274abdde1a4a8303509188 AS builder
 
 COPY . .
 
@@ -8,7 +8,7 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -o /tmp/openshift-builds-webhook ./cmd/shipwright-build-webhook
 
 # --- start build stage #2
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
 
 LABEL \
     com.redhat.component="openshift-builds-webhook" \


### PR DESCRIPTION
Update container images to use digest SHAs for go-toolset and ubi-minimal. These digests will help ensure reproducible builds and allow Renovate to submit PRs to bump base image dependencies. The go- toolset image was also updated to use golang 1.21 to align with upstream dependencies.

Also fixes BUILD-891, BUILD-892.