### PR TITLE
BUILD-1020: enable hermetic mode for builds

### DIFF
--- a/.docker/git-cloner/Dockerfile
+++ b/.docker/git-cloner/Dockerfile
@@ -8,7 +8,9 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -o /tmp/openshift-builds-git-cloner ./cmd/git
 
 # --- start build stage #2
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
+# RPM dependencies can't be fetched hermetically with Cachi2
+# Using UBI 9 which already includes necessary tar package
+FROM registry.access.redhat.com/ubi9/ubi:9.4@sha256:763f30167f92ec2af02bf7f09e75529de66e98f05373b88bef3c631cdcc39ad8
 
 LABEL \
   com.redhat.component="openshift-builds-git-cloner" \
@@ -22,9 +24,6 @@ LABEL \
   io.openshift.tags="builds,git-cloner"
 
 RUN \
-  microdnf --assumeyes --nodocs install git git-lfs && \
-  microdnf clean all && \
-  rm -rf /var/cache/yum && \
   echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
   echo 'nonroot:x:1000:' > /etc/group && \
   mkdir /.docker && chown 1000:1000 /.docker && \

--- a/.docker/image-bundler/Dockerfile
+++ b/.docker/image-bundler/Dockerfile
@@ -12,7 +12,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ad
 
 LABEL \
   com.redhat.component="openshift-builds-image-bundler" \
-  name="openshift-builds/image-bundler" \ 
+  name="openshift-builds/image-bundler" \
   version=${CI_CONTAINER_VERSION} \
   summary="Red Hat OpenShift Builds Image Bundler" \
   maintainer="openshift-builds@redhat.com" \

--- a/.docker/waiter/Dockerfile
+++ b/.docker/waiter/Dockerfile
@@ -8,7 +8,9 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -o /tmp/openshift-builds-waiter ./cmd/waiter
 
 # --- start build stage #2
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
+# RPM dependencies can't be fetched hermetically with Cachi2
+# Using UBI 9 which already includes necessary tar package
+FROM registry.access.redhat.com/ubi9/ubi:9.4@sha256:763f30167f92ec2af02bf7f09e75529de66e98f05373b88bef3c631cdcc39ad8
 
 LABEL \
   com.redhat.component="openshift-builds-waiter" \
@@ -22,9 +24,6 @@ LABEL \
   io.openshift.tags="builds,waiter"
 
 RUN \
-  microdnf --assumeyes --nodocs install tar && \
-  microdnf clean all && \
-  rm -rf /var/cache/yum && \
   echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
   echo 'nonroot:x:1000:' > /etc/group && \
   mkdir /.docker && \

--- a/.tekton/openshift-builds-controller-pull-request.yaml
+++ b/.tekton/openshift-builds-controller-pull-request.yaml
@@ -12,9 +12,9 @@ metadata:
       event == "pull_request" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('version/|pkg/controller/|pkg/client|pkg/reconciler|pkg/volumes|pkg/validate|pkg/env|pkg/metrics/|pkg/apis/|pkg/config/|pkg/ctxlog/|cmd/shipwright-build-controller/|.docker/controller/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||     
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||     
+        files.all.exists(x, x.matches('version/|pkg/controller/|pkg/client|pkg/reconciler|pkg/volumes|pkg/validate|pkg/env|pkg/metrics/|pkg/apis/|pkg/config/|pkg/ctxlog/|cmd/shipwright-build-controller/|.docker/controller/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-controller-pull-request.yaml'))
       )
   creationTimestamp: null
@@ -36,6 +36,12 @@ spec:
     value: 5d
   - name: dockerfile
     value: .docker/controller/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-controller-push.yaml
+++ b/.tekton/openshift-builds-controller-push.yaml
@@ -11,9 +11,9 @@ metadata:
       event == "push" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('version/|pkg/controller/|pkg/client|pkg/reconciler|pkg/volumes|pkg/validate|pkg/env|pkg/metrics/|pkg/apis/|pkg/config/|pkg/ctxlog/|cmd/shipwright-build-controller/|.docker/controller/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||     
+        files.all.exists(x, x.matches('version/|pkg/controller/|pkg/client|pkg/reconciler|pkg/volumes|pkg/validate|pkg/env|pkg/metrics/|pkg/apis/|pkg/config/|pkg/ctxlog/|cmd/shipwright-build-controller/|.docker/controller/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-controller-push.yaml'))
       )
   creationTimestamp: null
@@ -33,8 +33,12 @@ spec:
     value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-controller:{{revision}}
   - name: dockerfile
     value: .docker/controller/Dockerfile
-  - name: test-paths
-    value:
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-git-cloner-pull-request.yaml
+++ b/.tekton/openshift-builds-git-cloner-pull-request.yaml
@@ -10,11 +10,11 @@ metadata:
     pipelinesascode.tekton.dev/task: "[.tekton/openshift-builds-unit-test.yaml]"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "builds-1.1" && 
+      target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('cmd/git/|pkg/git/|.docker/git-cloner/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||   
+        files.all.exists(x, x.matches('cmd/git/|pkg/git/|.docker/git-cloner/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-git-cloner-pull-request.yaml'))
       )
   creationTimestamp: null
@@ -36,6 +36,12 @@ spec:
     value: 5d
   - name: dockerfile
     value: .docker/git-cloner/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-git-cloner-push.yaml
+++ b/.tekton/openshift-builds-git-cloner-push.yaml
@@ -11,9 +11,9 @@ metadata:
       event == "push" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('cmd/git/|pkg/git/|.docker/git-cloner/')) ||     
+        files.all.exists(x, x.matches('cmd/git/|pkg/git/|.docker/git-cloner/')) ||
         files.all.exists(x, x.matches('go.mod|go.sum')) ||
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||     
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-git-cloner-push.yaml'))
       )
   creationTimestamp: null
@@ -33,6 +33,12 @@ spec:
     value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-git-cloner:{{revision}}
   - name: dockerfile
     value: .docker/git-cloner/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-image-bundler-pull-request.yaml
+++ b/.tekton/openshift-builds-image-bundler-pull-request.yaml
@@ -36,6 +36,12 @@ spec:
     value: 5d
   - name: dockerfile
     value: .docker/image-bundler/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-image-bundler-push.yaml
+++ b/.tekton/openshift-builds-image-bundler-push.yaml
@@ -11,9 +11,9 @@ metadata:
       event == "push" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('cmd/bundle/|pkg/bundle/|pkg/image/|.docker/image-bundler/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||     
+        files.all.exists(x, x.matches('cmd/bundle/|pkg/bundle/|pkg/image/|.docker/image-bundler/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-image-bundler-push.yaml'))
       )
   creationTimestamp: null
@@ -33,6 +33,12 @@ spec:
     value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-image-bundler:{{revision}}
   - name: dockerfile
     value: .docker/image-bundler/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-image-processing-pull-request.yaml
+++ b/.tekton/openshift-builds-image-processing-pull-request.yaml
@@ -12,9 +12,9 @@ metadata:
       event == "pull_request" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('cmd/image-processing/|pkg/image/|.docker/image-processing/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||   
+        files.all.exists(x, x.matches('cmd/image-processing/|pkg/image/|.docker/image-processing/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-image-processing-pull-request.yaml'))
       )
   creationTimestamp: null
@@ -36,6 +36,12 @@ spec:
     value: 5d
   - name: dockerfile
     value: .docker/image-processing/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-image-processing-push.yaml
+++ b/.tekton/openshift-builds-image-processing-push.yaml
@@ -11,9 +11,9 @@ metadata:
       event == "push" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('cmd/image-processing/|pkg/image/|.docker/image-processing/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||     
+        files.all.exists(x, x.matches('cmd/image-processing/|pkg/image/|.docker/image-processing/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-image-processing-push.yaml'))
       )
   creationTimestamp: null
@@ -33,6 +33,12 @@ spec:
     value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-image-processing:{{revision}}
   - name: dockerfile
     value: .docker/image-processing/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-unit-test.yaml
+++ b/.tekton/openshift-builds-unit-test.yaml
@@ -25,7 +25,7 @@ spec:
       name: GOMODCACHE
   steps:
     - name: run-test
-      image: docker.io/library/golang:1.22
+      image: registry.access.redhat.com/ubi9/go-toolset:1.21@sha256:5c948cdfd0132e982426bc9d3a81eeae66871080ef274abdde1a4a8303509188
       env:
         - name: GOOS
           value: $(params.GOOS)

--- a/.tekton/openshift-builds-waiter-pull-request.yaml
+++ b/.tekton/openshift-builds-waiter-pull-request.yaml
@@ -12,9 +12,9 @@ metadata:
       event == "pull_request" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('cmd/waiter/|.docker/waiter/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||   
+        files.all.exists(x, x.matches('cmd/waiter/|.docker/waiter/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-waiter-pull-request.yaml'))
       )
   creationTimestamp: null
@@ -36,6 +36,12 @@ spec:
     value: 5d
   - name: dockerfile
     value: .docker/waiter/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-waiter-push.yaml
+++ b/.tekton/openshift-builds-waiter-push.yaml
@@ -11,9 +11,9 @@ metadata:
       event == "push" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('cmd/waiter/|.docker/waiter/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||     
+        files.all.exists(x, x.matches('cmd/waiter/|.docker/waiter/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-waiter-push.yaml'))
       )
   creationTimestamp: null
@@ -33,6 +33,12 @@ spec:
     value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-waiter:{{revision}}
   - name: dockerfile
     value: .docker/waiter/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-webhook-pull-request.yaml
@@ -12,9 +12,9 @@ metadata:
       event == "pull_request" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('version/|pkg/webhook/|pkg/ctxlog/|cmd/shipwright-build-webhook/|.docker/webhook/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||     
+        files.all.exists(x, x.matches('version/|pkg/webhook/|pkg/ctxlog/|cmd/shipwright-build-webhook/|.docker/webhook/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-webhook-pull-request.yaml'))
       )
   creationTimestamp: null
@@ -36,6 +36,12 @@ spec:
     value: 5d
   - name: dockerfile
     value: .docker/webhook/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/openshift-builds-webhook-push.yaml
+++ b/.tekton/openshift-builds-webhook-push.yaml
@@ -11,9 +11,9 @@ metadata:
       event == "push" &&
       target_branch == "builds-1.1" &&
       (
-        files.all.exists(x, x.matches('version/|pkg/webhook/|pkg/ctxlog/|cmd/shipwright-build-webhook/|.docker/webhook/')) ||      
-        files.all.exists(x, x.matches('go.mod|go.sum')) ||   
-        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||     
+        files.all.exists(x, x.matches('version/|pkg/webhook/|pkg/ctxlog/|cmd/shipwright-build-webhook/|.docker/webhook/')) ||
+        files.all.exists(x, x.matches('go.mod|go.sum')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-unit-test.yaml')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-webhook-push.yaml'))
       )
   creationTimestamp: null
@@ -33,6 +33,12 @@ spec:
     value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-webhook:{{revision}}
   - name: dockerfile
     value: .docker/webhook/Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
+    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
+    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
enable hermetic mode for builds
- address EC violation of non-hermetic build
- use ubi9/ubi image for pre-installed tar package as rpm dependencies can't be met hermetically
- use trusted registry for golang images

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED