### PR TITLE
disable hermetic build for git-cloner & waiter

### DIFF
--- a/.docker/git-cloner/Dockerfile
+++ b/.docker/git-cloner/Dockerfile
@@ -18,9 +18,7 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-git-cloner ./cmd/git
 
 # --- start build stage #2
-# RPM dependencies can't be fetched hermetically with Cachi2
-# Using UBI 9 which already includes necessary tar package
-FROM registry.access.redhat.com/ubi9/ubi:9.4@sha256:763f30167f92ec2af02bf7f09e75529de66e98f05373b88bef3c631cdcc39ad8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:73f7dcacb460dad137a58f24668470a5a2e47378838a0190eef0ab532c6e8998
 
 LABEL \
     com.redhat.component="openshift-builds-git-cloner" \
@@ -34,6 +32,9 @@ LABEL \
     io.openshift.tags="builds,git-cloner"
 
 RUN \
+  microdnf --assumeyes --nodocs install git git-lfs && \
+  microdnf clean all && \
+  rm -rf /var/cache/yum && \
   echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
   echo 'nonroot:x:1000:' > /etc/group && \
   mkdir /.docker && chown 1000:1000 /.docker && \
@@ -43,4 +44,3 @@ COPY --from=builder /opt/app-root/src/openshift-builds-git-cloner .
 COPY LICENSE /licenses/
 
 ENTRYPOINT ["./openshift-builds-git-cloner"]
-

--- a/.docker/waiter/Dockerfile
+++ b/.docker/waiter/Dockerfile
@@ -18,9 +18,7 @@ RUN go version
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-waiter ./cmd/waiter
 
 # --- start build stage #2
-# RPM dependencies can't be fetched hermetically with Cachi2
-# Using UBI 9 which already includes necessary tar package
-FROM registry.access.redhat.com/ubi9/ubi:9.4@sha256:763f30167f92ec2af02bf7f09e75529de66e98f05373b88bef3c631cdcc39ad8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:73f7dcacb460dad137a58f24668470a5a2e47378838a0190eef0ab532c6e8998
 
 LABEL \
     com.redhat.component="openshift-builds-waiter" \
@@ -34,6 +32,9 @@ LABEL \
     io.openshift.tags="builds,waiter"
 
 RUN \
+  microdnf --assumeyes --nodocs install tar && \
+  microdnf clean all && \
+  rm -rf /var/cache/yum && \
   echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
   echo 'nonroot:x:1000:' > /etc/group && \
   mkdir /.docker && \

--- a/.tekton/openshift-builds-git-cloner-pull-request.yaml
+++ b/.tekton/openshift-builds-git-cloner-pull-request.yaml
@@ -37,11 +37,7 @@ spec:
   - name: dockerfile
     value: .docker/git-cloner/Dockerfile
   - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
-    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
-    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineSpec:

--- a/.tekton/openshift-builds-git-cloner-push.yaml
+++ b/.tekton/openshift-builds-git-cloner-push.yaml
@@ -34,11 +34,7 @@ spec:
   - name: dockerfile
     value: .docker/git-cloner/Dockerfile
   - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
-    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
-    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineSpec:

--- a/.tekton/openshift-builds-waiter-pull-request.yaml
+++ b/.tekton/openshift-builds-waiter-pull-request.yaml
@@ -37,11 +37,7 @@ spec:
   - name: dockerfile
     value: .docker/waiter/Dockerfile
   - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
-    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
-    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineSpec:

--- a/.tekton/openshift-builds-waiter-push.yaml
+++ b/.tekton/openshift-builds-waiter-push.yaml
@@ -34,11 +34,7 @@ spec:
   - name: dockerfile
     value: .docker/waiter/Dockerfile
   - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    # --gomod-vendor-check - if the vendor/ directory does not exist, do the same thing as gomod-vendor.
-    # Otherwise, call go mod vendor and verify that nothing changed in the vendor/ directory. If anything did change, raise an error.
-    value: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
+    value: "false"
   - name: build-source-image
     value: "true"
   pipelineSpec:


### PR DESCRIPTION
    - rpm dependencies can't be met hermetically for now. 
       It should be possible in future to do so.
    - revert to using ubi-minimal

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED