### PR TITLE
fix: Binary location in the container

### DIFF
--- a/.konflux/git-cloner/Dockerfile
+++ b/.konflux/git-cloner/Dockerfile
@@ -31,10 +31,10 @@ RUN \
   mkdir /.docker && chown 1000:1000 /.docker && \
   mkdir /.ssh && chown 1000:1000 /.ssh
 
-COPY --from=builder /opt/app-root/src/openshift-builds-git-cloner .
+COPY --from=builder /opt/app-root/src/openshift-builds-git-cloner /ko-app/git
 COPY LICENSE /licenses/
 
-ENTRYPOINT ["./openshift-builds-git-cloner"]
+ENTRYPOINT ["/ko-app/git"]
 
 LABEL \
     com.redhat.component="openshift-builds-git-cloner" \

--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -28,10 +28,10 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-image-bundler .
+COPY --from=builder /opt/app-root/src/openshift-builds-image-bundler /ko-app/bundle
 COPY LICENSE /licenses/
 
-ENTRYPOINT ["./openshift-builds-image-bundler"]
+ENTRYPOINT ["/ko-app/bundle"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-bundler" \

--- a/.konflux/image-processing/Dockerfile
+++ b/.konflux/image-processing/Dockerfile
@@ -28,10 +28,10 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-image-processing .
+COPY --from=builder /opt/app-root/src/openshift-builds-image-processing /ko-app/image-processing
 COPY LICENSE /licenses/
 
-ENTRYPOINT ["./openshift-builds-image-processing"]
+ENTRYPOINT ["/ko-app/image-processing"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-processing" \

--- a/.konflux/waiter/Dockerfile
+++ b/.konflux/waiter/Dockerfile
@@ -31,10 +31,10 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-waiter .
+COPY --from=builder /opt/app-root/src/openshift-builds-waiter /ko-app/waiter
 COPY LICENSE /licenses/
 
-ENTRYPOINT ["./openshift-builds-waiter"]
+ENTRYPOINT ["/ko-app/waiter"]
 
 LABEL \
     com.redhat.component="openshift-builds-waiter" \


### PR DESCRIPTION
Changes:
- Binary location for `git-cloner`, `waiter`, `image-processing` and `image-bundler` are updated to `/ko-app/` since this is hardcoded in the upstream source code.