### PR TITLE
Build single architecture for builds 1.1

### DIFF
--- a/.tekton/openshift-builds-controller-pull-request.yaml
+++ b/.tekton/openshift-builds-controller-pull-request.yaml
@@ -119,9 +119,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-controller-push.yaml
+++ b/.tekton/openshift-builds-controller-push.yaml
@@ -116,9 +116,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-git-cloner-pull-request.yaml
+++ b/.tekton/openshift-builds-git-cloner-pull-request.yaml
@@ -123,9 +123,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-git-cloner-push.yaml
+++ b/.tekton/openshift-builds-git-cloner-push.yaml
@@ -120,9 +120,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-image-bundler-pull-request.yaml
+++ b/.tekton/openshift-builds-image-bundler-pull-request.yaml
@@ -119,9 +119,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-image-bundler-push.yaml
+++ b/.tekton/openshift-builds-image-bundler-push.yaml
@@ -116,9 +116,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-image-processing-pull-request.yaml
+++ b/.tekton/openshift-builds-image-processing-pull-request.yaml
@@ -119,9 +119,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-image-processing-push.yaml
+++ b/.tekton/openshift-builds-image-processing-push.yaml
@@ -116,9 +116,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-waiter-pull-request.yaml
+++ b/.tekton/openshift-builds-waiter-pull-request.yaml
@@ -123,9 +123,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-waiter-push.yaml
+++ b/.tekton/openshift-builds-waiter-push.yaml
@@ -120,9 +120,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-webhook-pull-request.yaml
@@ -119,9 +119,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms

--- a/.tekton/openshift-builds-webhook-push.yaml
+++ b/.tekton/openshift-builds-webhook-push.yaml
@@ -116,9 +116,6 @@ spec:
         type: string
       - default:
           - linux/x86_64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/s390x
         description: List of platforms to build the container images on. The available
           set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms


### PR DESCRIPTION
Changes:
- Remove all build architecture except linux/x86_64