### PR TITLE
Disable ppc64le and s390x architecture for pull request

### DIFF
--- a/.tekton/openshift-builds-controller-pull-request.yaml
+++ b/.tekton/openshift-builds-controller-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-controller-push.yaml
+++ b/.tekton/openshift-builds-controller-push.yaml
@@ -35,6 +35,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-git-cloner-pull-request.yaml
+++ b/.tekton/openshift-builds-git-cloner-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"},{"type": "rpm","path": ".konflux/git-cloner"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-git-cloner-push.yaml
+++ b/.tekton/openshift-builds-git-cloner-push.yaml
@@ -35,6 +35,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"},{"type": "rpm","path": ".konflux/git-cloner"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-image-bundler-pull-request.yaml
+++ b/.tekton/openshift-builds-image-bundler-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-image-bundler-push.yaml
+++ b/.tekton/openshift-builds-image-bundler-push.yaml
@@ -35,6 +35,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-image-processing-pull-request.yaml
+++ b/.tekton/openshift-builds-image-processing-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-image-processing-push.yaml
+++ b/.tekton/openshift-builds-image-processing-push.yaml
@@ -35,6 +35,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-waiter-pull-request.yaml
+++ b/.tekton/openshift-builds-waiter-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"},{"type": "rpm","path": ".konflux/waiter"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-waiter-push.yaml
+++ b/.tekton/openshift-builds-waiter-push.yaml
@@ -35,6 +35,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"},{"type": "rpm","path": ".konflux/waiter"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-webhook-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-webhook-push.yaml
+++ b/.tekton/openshift-builds-webhook-push.yaml
@@ -35,6 +35,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:


### PR DESCRIPTION
Changes:
- Update tekton pipelines to disable ppc64le and s390x architecture for pull request