### PR TITLE
[Builds-1.3] fix: Replacing the builder image and adding workdir in Dockerfiles to fix buildvcs errors

### DIFF
--- a/.konflux/controller/Dockerfile
+++ b/.konflux/controller/Dockerfile
@@ -1,12 +1,14 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:6402ad7886fb3bdaa950c89bdf338f8dbedde54c16bddb1157ebb8691b2def50 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:42c9557a27ecb3909796ad47170ad6c06a023fde89588526cb8f2b0e4e6bae84 AS builder
+USER root
 
+WORKDIR /workspace
 COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-controller ./cmd/shipwright-build-controller
 
 FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
-COPY --from=builder /opt/app-root/src/openshift-builds-controller .
+COPY --from=builder /workspace/openshift-builds-controller /ko-app/git
 COPY LICENSE /licenses/
 
 ENTRYPOINT ["./openshift-builds-controller"]

--- a/.konflux/controller/Dockerfile
+++ b/.konflux/controller/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-controller ./cmd/shipwright-build-controller
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
+FROM registry.access.redhat.com/ubi9-minimal@sha256:30bbd445046a3a63f5f5557a3c67dee74e3c8e7855eb0347630b020f3689823f
 
 COPY --from=builder /workspace/openshift-builds-controller /ko-app/git
 COPY LICENSE /licenses/

--- a/.konflux/git-cloner/Dockerfile
+++ b/.konflux/git-cloner/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-git-cloner ./cmd/git
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
+FROM registry.access.redhat.com/ubi9-minimal@sha256:30bbd445046a3a63f5f5557a3c67dee74e3c8e7855eb0347630b020f3689823f
 
 RUN \
   microdnf --assumeyes --nodocs install git git-lfs && \

--- a/.konflux/git-cloner/Dockerfile
+++ b/.konflux/git-cloner/Dockerfile
@@ -1,5 +1,7 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:6402ad7886fb3bdaa950c89bdf338f8dbedde54c16bddb1157ebb8691b2def50 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:42c9557a27ecb3909796ad47170ad6c06a023fde89588526cb8f2b0e4e6bae84 AS builder
+USER root
 
+WORKDIR /workspace
 COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-git-cloner ./cmd/git
@@ -15,10 +17,10 @@ RUN \
   mkdir /.docker && chown 1000:1000 /.docker && \
   mkdir /.ssh && chown 1000:1000 /.ssh
 
-COPY --from=builder /opt/app-root/src/openshift-builds-git-cloner /ko-app/git
+COPY --from=builder /workspace/openshift-builds-git-cloner /ko-app/git
 COPY LICENSE /licenses/
 
-ENTRYPOINT ["/ko-app/git"]
+ENTRYPOINT ["./openshift-builds-git-cloner"]
 
 LABEL \
     com.redhat.component="openshift-builds-git-cloner" \

--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-image-bundler ./cmd/bundle
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
+FROM registry.access.redhat.com/ubi9-minimal@sha256:30bbd445046a3a63f5f5557a3c67dee74e3c8e7855eb0347630b020f3689823f
 
 RUN \
   microdnf clean all && \

--- a/.konflux/image-bundler/Dockerfile
+++ b/.konflux/image-bundler/Dockerfile
@@ -1,5 +1,7 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:6402ad7886fb3bdaa950c89bdf338f8dbedde54c16bddb1157ebb8691b2def50 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:42c9557a27ecb3909796ad47170ad6c06a023fde89588526cb8f2b0e4e6bae84 AS builder
+USER root
 
+WORKDIR /workspace
 COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-image-bundler ./cmd/bundle
@@ -14,10 +16,10 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-image-bundler /ko-app/bundle
+COPY --from=builder /workspace/openshift-builds-image-bundler /ko-app/git
 COPY LICENSE /licenses/
 
-ENTRYPOINT ["/ko-app/bundle"]
+ENTRYPOINT ["./openshift-builds-image-bundler"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-bundler" \

--- a/.konflux/image-processing/Dockerfile
+++ b/.konflux/image-processing/Dockerfile
@@ -1,5 +1,7 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:6402ad7886fb3bdaa950c89bdf338f8dbedde54c16bddb1157ebb8691b2def50 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:42c9557a27ecb3909796ad47170ad6c06a023fde89588526cb8f2b0e4e6bae84 AS builder
+USER root
 
+WORKDIR /workspace
 COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-image-processing ./cmd/image-processing
@@ -14,10 +16,10 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-image-processing /ko-app/image-processing
+COPY --from=builder /workspace/openshift-builds-image-processing /ko-app/git
 COPY LICENSE /licenses/
 
-ENTRYPOINT ["/ko-app/image-processing"]
+ENTRYPOINT ["./openshift-builds-image-processing"]
 
 LABEL \
     com.redhat.component="openshift-builds-image-processing" \

--- a/.konflux/image-processing/Dockerfile
+++ b/.konflux/image-processing/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-image-processing ./cmd/image-processing
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
+FROM registry.access.redhat.com/ubi9-minimal@sha256:30bbd445046a3a63f5f5557a3c67dee74e3c8e7855eb0347630b020f3689823f
 
 RUN \
   microdnf clean all && \

--- a/.konflux/waiter/Dockerfile
+++ b/.konflux/waiter/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-waiter ./cmd/waiter
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
+FROM registry.access.redhat.com/ubi9-minimal@sha256:30bbd445046a3a63f5f5557a3c67dee74e3c8e7855eb0347630b020f3689823f
 
 RUN \
   microdnf --assumeyes --nodocs install tar && \

--- a/.konflux/waiter/Dockerfile
+++ b/.konflux/waiter/Dockerfile
@@ -1,5 +1,7 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:6402ad7886fb3bdaa950c89bdf338f8dbedde54c16bddb1157ebb8691b2def50 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:42c9557a27ecb3909796ad47170ad6c06a023fde89588526cb8f2b0e4e6bae84 AS builder
+USER root
 
+WORKDIR /workspace
 COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-waiter ./cmd/waiter
@@ -15,10 +17,10 @@ RUN \
   mkdir /.docker && \
   chown 1000:1000 /.docker
 
-COPY --from=builder /opt/app-root/src/openshift-builds-waiter /ko-app/waiter
+COPY --from=builder /workspace/openshift-builds-waiter /ko-app/git
 COPY LICENSE /licenses/
 
-ENTRYPOINT ["/ko-app/waiter"]
+ENTRYPOINT ["./openshift-builds-waiter"]
 
 LABEL \
     com.redhat.component="openshift-builds-waiter" \

--- a/.konflux/webhook/Dockerfile
+++ b/.konflux/webhook/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-webhook ./cmd/shipwright-build-webhook
 
-FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
+FROM registry.access.redhat.com/ubi9-minimal@sha256:30bbd445046a3a63f5f5557a3c67dee74e3c8e7855eb0347630b020f3689823f
 
 COPY --from=builder /workspace/openshift-builds-webhook /ko-app/git
 COPY LICENSE /licenses/

--- a/.konflux/webhook/Dockerfile
+++ b/.konflux/webhook/Dockerfile
@@ -1,12 +1,14 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:6402ad7886fb3bdaa950c89bdf338f8dbedde54c16bddb1157ebb8691b2def50 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:42c9557a27ecb3909796ad47170ad6c06a023fde89588526cb8f2b0e4e6bae84 AS builder
+USER root
 
+WORKDIR /workspace
 COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -ldflags="-s -w" -o openshift-builds-webhook ./cmd/shipwright-build-webhook
 
 FROM registry.access.redhat.com/ubi9-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
 
-COPY --from=builder /opt/app-root/src/openshift-builds-webhook .
+COPY --from=builder /workspace/openshift-builds-webhook /ko-app/git
 COPY LICENSE /licenses/
 
 ENTRYPOINT ["./openshift-builds-webhook"]
@@ -21,3 +23,4 @@ LABEL \
     io.k8s.description="Red Hat OpenShift Builds Webhook" \
     io.k8s.display-name="Red Hat OpenShift Builds Webhook" \
     io.openshift.tags="builds,conversion-webhook"
+    


### PR DESCRIPTION
Adding a WORKDIR to dockerfile to have relative accesible paths.